### PR TITLE
Update macOS installation instructions for Clang

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ app {
 **Prerequisites:**
 - Clang 16+ (required for full C++20 support)
   - Ubuntu/Debian: `sudo apt install clang-16`
-  - macOS: `brew install llvm`
+  - macOS: `brew install llvm lld`
   - Fedora: `sudo dnf install clang`
 
 ```bash


### PR DESCRIPTION
Without the `lld` package I the `wasm-ld` executable is not installed.