### PR TITLE
Clean up comments in run.py

### DIFF
--- a/tests/run.py
+++ b/tests/run.py
@@ -5,8 +5,6 @@ Coi Test Runner
 
 import argparse
 from pathlib import Path
-
-# Fix module search path if needed
 import sys
 sys.path.append(str(Path(__file__).parent))
 


### PR DESCRIPTION
Remove unnecessary comment about fixing module search path.