### PR TITLE
Add dispatcher usage check for loop regions

### DIFF
--- a/src/ast/component/to_webcc.cc
+++ b/src/ast/component/to_webcc.cc
@@ -114,35 +114,14 @@ static std::string indent_code(const std::string &code, const std::string &prefi
     return indented.str();
 }
 
-// Check whether this component's generated code can reference a dispatcher.
-// We inspect both regular event handlers and loop item code for inline dispatcher.set(...).
-static bool component_uses_dispatcher(const std::vector<EventHandler> &handlers,
-                                      const std::vector<LoopRegion> &loop_regions,
-                                      const std::string &event_type,
-                                      const std::string &dispatcher_name)
+// Check whether loop-generated code for a specific region registers handlers
+// on a given dispatcher.
+static bool loop_region_uses_dispatcher(const LoopRegion &region,
+                                        const std::string &dispatcher_name)
 {
-    for (const auto &handler : handlers)
-    {
-        if (handler.event_type == event_type)
-        {
-            return true;
-        }
-    }
-
     std::string needle = dispatcher_name + ".set(";
-    for (const auto &region : loop_regions)
-    {
-        if (region.item_creation_code.find(needle) != std::string::npos)
-        {
-            return true;
-        }
-        if (region.item_update_code.find(needle) != std::string::npos)
-        {
-            return true;
-        }
-    }
-
-    return false;
+    return region.item_creation_code.find(needle) != std::string::npos ||
+           region.item_update_code.find(needle) != std::string::npos;
 }
 
 // ============================================================================
@@ -944,7 +923,7 @@ std::string Component::to_webcc(CompilerSession &session)
                 ss << "        for (auto& _el : " << elements_vec << ") {\n";
                 for (const auto &spec : get_event_specs())
                 {
-                    if (component_uses_dispatcher(event_handlers, loop_regions, spec.type, spec.dispatcher_name))
+                    if (loop_region_uses_dispatcher(region, spec.dispatcher_name))
                     {
                         ss << "            " << spec.dispatcher_name << ".remove(_el);\n";
                     }
@@ -1071,7 +1050,7 @@ std::string Component::to_webcc(CompilerSession &session)
         ss << "            webcc::handle _old = " << elements_vec << "[_idx];\n";
         for (const auto &spec : get_event_specs())
         {
-            if (component_uses_dispatcher(event_handlers, loop_regions, spec.type, spec.dispatcher_name))
+            if (loop_region_uses_dispatcher(region, spec.dispatcher_name))
             {
                 ss << "            " << spec.dispatcher_name << ".remove(_old);\n";
             }

--- a/src/ast/component/to_webcc.cc
+++ b/src/ast/component/to_webcc.cc
@@ -114,6 +114,37 @@ static std::string indent_code(const std::string &code, const std::string &prefi
     return indented.str();
 }
 
+// Check whether this component's generated code can reference a dispatcher.
+// We inspect both regular event handlers and loop item code for inline dispatcher.set(...).
+static bool component_uses_dispatcher(const std::vector<EventHandler> &handlers,
+                                      const std::vector<LoopRegion> &loop_regions,
+                                      const std::string &event_type,
+                                      const std::string &dispatcher_name)
+{
+    for (const auto &handler : handlers)
+    {
+        if (handler.event_type == event_type)
+        {
+            return true;
+        }
+    }
+
+    std::string needle = dispatcher_name + ".set(";
+    for (const auto &region : loop_regions)
+    {
+        if (region.item_creation_code.find(needle) != std::string::npos)
+        {
+            return true;
+        }
+        if (region.item_update_code.find(needle) != std::string::npos)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 // ============================================================================
 // Code Generation Helpers
 // ============================================================================
@@ -913,7 +944,10 @@ std::string Component::to_webcc(CompilerSession &session)
                 ss << "        for (auto& _el : " << elements_vec << ") {\n";
                 for (const auto &spec : get_event_specs())
                 {
-                    ss << "            " << spec.dispatcher_name << ".remove(_el);\n";
+                    if (component_uses_dispatcher(event_handlers, loop_regions, spec.type, spec.dispatcher_name))
+                    {
+                        ss << "            " << spec.dispatcher_name << ".remove(_el);\n";
+                    }
                 }
                 ss << "            webcc::dom::remove_element(_el);\n";
                 ss << "        }\n";
@@ -1037,7 +1071,10 @@ std::string Component::to_webcc(CompilerSession &session)
         ss << "            webcc::handle _old = " << elements_vec << "[_idx];\n";
         for (const auto &spec : get_event_specs())
         {
-            ss << "            " << spec.dispatcher_name << ".remove(_old);\n";
+            if (component_uses_dispatcher(event_handlers, loop_regions, spec.type, spec.dispatcher_name))
+            {
+                ss << "            " << spec.dispatcher_name << ".remove(_old);\n";
+            }
         }
         ss << "            webcc::dom::remove_element(_old);\n";
         ss << "            _ref = (_idx + 1 < (int)" << elements_vec << ".size()) ? " << elements_vec << "[_idx + 1] : " << anchor_var << ";\n";


### PR DESCRIPTION
Introduce a function to verify if loop-generated code registers handlers on a specified dispatcher. Simplify the dispatcher usage check within loop regions to enhance code clarity and maintainability.