### PR TITLE
Add Storage.getItem method and update documentation

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -240,14 +240,25 @@ Local storage for persisting data.
 | Method | Description |
 |--------|-------------|
 | `Storage.setItem(string key, string value)` | Store a key-value pair |
+| `Storage.getItem(string key)` | Read a value by key (returns `""` if the key is missing) |
 | `Storage.removeItem(string key)` | Remove item by key |
 | `Storage.clear()` | Clear all stored items |
+
+> **Note:** `getItem` returns an empty string (`""`) for a missing key, so use `.isEmpty()` to detect "not set".
 
 ### Example
 
 ```tsx
 component Settings {
     mut string theme = "light";
+
+    init {
+        // Restore the saved theme on startup (defaults to "light").
+        string saved = Storage.getItem("theme");
+        if (!saved.isEmpty()) {
+            theme = saved;
+        }
+    }
 
     def saveTheme() : void {
         Storage.setItem("theme", theme);
@@ -879,7 +890,7 @@ component Chat {
 | `Canvas`     | 2D drawing, paths, text, images, transformations |
 | `Image`      | Image loading for canvas rendering               |
 | `Audio`      | Audio playback, volume, looping, playback position |
-| `Storage`    | Local storage (setItem, removeItem, clear)       |
+| `Storage`    | Local storage (setItem, getItem, removeItem, clear) |
 | `System`     | Logging, page title, time, random, URL navigation |
 | `Input`      | Keyboard input, pointer lock                     |
 | `DOMElement` | Direct DOM manipulation                          |

--- a/src/tools/schema_whitelist.def
+++ b/src/tools/schema_whitelist.def
@@ -87,6 +87,7 @@ exit_pointer_lock
 
 [storage]
 set_item
+get_item
 remove_item
 clear
 


### PR DESCRIPTION
This pull request adds support for reading values from local storage with a new `getItem` method, updates the documentation to reflect this addition, and ensures that the schema whitelist and dependency references are up to date. The most important changes are:

**Local Storage API Enhancements:**

* Added the `Storage.getItem(string key)` method to the local storage API, allowing retrieval of values by key and returning an empty string if the key is missing.
* Updated the documentation to include `getItem` in the list of available `Storage` methods and provided notes and examples on its usage. [[1]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cR243-R262) [[2]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cL882-R893)

**Schema and Dependency Updates:**

* Added `get_item` to the `[storage]` section in `schema_whitelist.def` to permit its use.
* Updated the `webcc` submodule to the latest commit, ensuring dependencies are current.