### PR TITLE
Added System.getTimezoneOffsetMs(), and updated docs

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -349,7 +349,8 @@ Logging, page title, time, random numbers, and URL navigation.
 | `System.openUrl(string url)` | Open URL in new tab |
 | `System.navigate(string path)` | Navigate to route (client-side routing) |
 | `System.getTime()` | Get time in seconds (float64) |
-| `System.getDateNow()` | Get milliseconds since epoch (float64) |
+| `System.getDateNow()` | Get milliseconds since epoch, UTC (float64) |
+| `System.getTimezoneOffsetMs()` | Local timezone offset from UTC in milliseconds (float64; add to a UTC epoch ms to get local time) |
 | `System.getVisibilityState()` | Get document visibility state (`"visible"`, `"hidden"`, etc.) |
 | `System.isHidden()` | Check if document is hidden (`true` hidden, `false` visible) |
 | `System.random()` | Random float between 0.0 and 1.0 |

--- a/src/tools/schema_whitelist.def
+++ b/src/tools/schema_whitelist.def
@@ -108,6 +108,7 @@ reload
 open_url
 get_time
 get_date_now
+get_timezone_offset_ms
 get_pathname
 get_search
 get_query_param


### PR DESCRIPTION
This pull request introduces a new system API for retrieving the local timezone offset in milliseconds, updates documentation to clarify time-related methods, and updates the schema whitelist and submodule reference. The main focus is on improving date and time handling capabilities.

**API and Documentation Improvements:**

* Added a new system API: `System.getTimezoneOffsetMs()` to retrieve the local timezone offset from UTC in milliseconds, and documented its usage.
* Clarified the documentation for `System.getDateNow()` to specify that it returns milliseconds since epoch in UTC.

**Schema and Dependency Updates:**

* Added `get_timezone_offset_ms` to the `schema_whitelist.def` file, allowing it to be used in the schema.
* Updated the `webcc` submodule to a newer commit, potentially bringing in upstream bug fixes or features.