### PR TITLE
feat: add match arm reactivity tests and implementation

### DIFF
--- a/src/ast/statements.cc
+++ b/src/ast/statements.cc
@@ -601,6 +601,105 @@ void EmitStatement::collect_dependencies(std::set<std::string> &deps)
     }
 }
 
+// Collect fields mutated by an expression in statement position. Shared by
+// top-level expression statements and match-arm bodies.
+static void collect_mods_in_expr(Expression *expr, std::set<std::string> &mods)
+{
+    if (!expr)
+        return;
+
+    if (auto postfix = dynamic_cast<PostfixOp *>(expr))
+    {
+        if (auto id = dynamic_cast<Identifier *>(postfix->operand.get()))
+        {
+            mods.insert(id->name);
+        }
+    }
+    else if (auto unary = dynamic_cast<UnaryOp *>(expr))
+    {
+        if (unary->op == "++" || unary->op == "--")
+        {
+            if (auto id = dynamic_cast<Identifier *>(unary->operand.get()))
+            {
+                mods.insert(id->name);
+            }
+        }
+    }
+    else if (auto call = dynamic_cast<FunctionCall *>(expr))
+    {
+        size_t dot_pos = call->name.rfind('.');
+        if (dot_pos != std::string::npos)
+        {
+            std::string method = call->name.substr(dot_pos + 1);
+            std::string obj_expr = call->name.substr(0, dot_pos);
+
+            // Check if this is a mutating method (returns void) on ANY type
+            // This includes: string.append(), array.push(), etc.
+            // We need to check all possible types since we don't have type info here
+            bool is_mutating = false;
+            std::vector<std::string> types_to_check = {"string", "array", "int", "float", "bool"};
+            for (const auto& type : types_to_check)
+            {
+                auto* method_def = DefSchema::instance().lookup_method(type, method);
+                if (method_def && method_def->return_type == "void")
+                {
+                    is_mutating = true;
+                    break;
+                }
+            }
+
+            if (is_mutating)
+            {
+                // For simple identifiers like "label.append()", track "label"
+                // For member access like "rows[i].label.append()", track the root variable
+                // We need to parse obj_expr to find the root identifier
+
+                // Find the root variable name (leftmost identifier before any . or [)
+                size_t first_dot = obj_expr.find('.');
+                size_t first_bracket = obj_expr.find('[');
+                size_t split_pos = std::string::npos;
+
+                if (first_dot != std::string::npos && first_bracket != std::string::npos)
+                {
+                    split_pos = std::min(first_dot, first_bracket);
+                }
+                else if (first_dot != std::string::npos)
+                {
+                    split_pos = first_dot;
+                }
+                else if (first_bracket != std::string::npos)
+                {
+                    split_pos = first_bracket;
+                }
+
+                std::string root_var = (split_pos != std::string::npos)
+                    ? obj_expr.substr(0, split_pos)
+                    : obj_expr;
+                mods.insert(root_var);
+            }
+        }
+    }
+    else if (auto match = dynamic_cast<MatchExpr *>(expr))
+    {
+        // Descend into arm bodies so assignments inside a match mark fields dirty.
+        for (auto &arm : match->arms)
+        {
+            Expression *body = arm.body.get();
+            if (auto block = dynamic_cast<BlockExpr *>(body))
+            {
+                for (auto &s : block->statements)
+                {
+                    collect_mods_recursive(s.get(), mods);
+                }
+            }
+            else
+            {
+                collect_mods_in_expr(body, mods);
+            }
+        }
+    }
+}
+
 void collect_mods_recursive(Statement *stmt, std::set<std::string> &mods)
 {
     if (auto assign = dynamic_cast<Assignment *>(stmt))
@@ -634,77 +733,7 @@ void collect_mods_recursive(Statement *stmt, std::set<std::string> &mods)
     }
     else if (auto exprStmt = dynamic_cast<ExpressionStatement *>(stmt))
     {
-        if (auto postfix = dynamic_cast<PostfixOp *>(exprStmt->expression.get()))
-        {
-            if (auto id = dynamic_cast<Identifier *>(postfix->operand.get()))
-            {
-                mods.insert(id->name);
-            }
-        }
-        else if (auto unary = dynamic_cast<UnaryOp *>(exprStmt->expression.get()))
-        {
-            if (unary->op == "++" || unary->op == "--")
-            {
-                if (auto id = dynamic_cast<Identifier *>(unary->operand.get()))
-                {
-                    mods.insert(id->name);
-                }
-            }
-        }
-        else if (auto call = dynamic_cast<FunctionCall *>(exprStmt->expression.get()))
-        {
-            size_t dot_pos = call->name.rfind('.');
-            if (dot_pos != std::string::npos)
-            {
-                std::string method = call->name.substr(dot_pos + 1);
-                std::string obj_expr = call->name.substr(0, dot_pos);
-                
-                // Check if this is a mutating method (returns void) on ANY type
-                // This includes: string.append(), array.push(), etc.
-                // We need to check all possible types since we don't have type info here
-                bool is_mutating = false;
-                std::vector<std::string> types_to_check = {"string", "array", "int", "float", "bool"};
-                for (const auto& type : types_to_check)
-                {
-                    auto* method_def = DefSchema::instance().lookup_method(type, method);
-                    if (method_def && method_def->return_type == "void")
-                    {
-                        is_mutating = true;
-                        break;
-                    }
-                }
-                
-                if (is_mutating)
-                {
-                    // For simple identifiers like "label.append()", track "label"
-                    // For member access like "rows[i].label.append()", track the root variable
-                    // We need to parse obj_expr to find the root identifier
-                    
-                    // Find the root variable name (leftmost identifier before any . or [)
-                    size_t first_dot = obj_expr.find('.');
-                    size_t first_bracket = obj_expr.find('[');
-                    size_t split_pos = std::string::npos;
-                    
-                    if (first_dot != std::string::npos && first_bracket != std::string::npos)
-                    {
-                        split_pos = std::min(first_dot, first_bracket);
-                    }
-                    else if (first_dot != std::string::npos)
-                    {
-                        split_pos = first_dot;
-                    }
-                    else if (first_bracket != std::string::npos)
-                    {
-                        split_pos = first_bracket;
-                    }
-                    
-                    std::string root_var = (split_pos != std::string::npos) 
-                        ? obj_expr.substr(0, split_pos) 
-                        : obj_expr;
-                    mods.insert(root_var);
-                }
-            }
-        }
+        collect_mods_in_expr(exprStmt->expression.get(), mods);
     }
     else if (auto block = dynamic_cast<BlockStatement *>(stmt))
     {

--- a/tests/integration/web/scenes/match_arm_reactivity_click.coi
+++ b/tests/integration/web/scenes/match_arm_reactivity_click.coi
@@ -1,0 +1,41 @@
+// Regression scene: assigning state inside a match arm must re-render the view.
+// Covers both the literal-match and Json.parse variant forms.
+
+pod Ping { bool ok; }
+
+component App {
+  mut int step = 0;
+  mut string word = "start";
+  mut string parsed = "none";
+
+  def click() : void {
+    step += 1;
+    match (step) {
+      1 => { word = "one"; };
+      2 => { word = "two"; };
+      else => { word = "many"; };
+    };
+    match (Json.parse(Ping, `{"ok":true}`)) {
+      Success(Ping p, Meta m) => { parsed = p.ok ? "parsed" : "unparsed"; };
+      Error(string e) => { parsed = "error"; };
+    };
+  }
+
+  style {
+    html, body { margin: 0; padding: 0; background: #0f1117; color: #e8e8e8;
+      font-family: system-ui, sans-serif; }
+    .hit { width: 100vw; height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 12px; user-select: none; cursor: pointer; }
+    .word { font-size: 40px; }
+    .parsed { font-size: 24px; opacity: 0.85; }
+  }
+
+  view {
+    <div class="hit hit" onclick={click}>
+      <div class="word word">{word}</div>
+      <div class="parsed parsed">{parsed}</div>
+    </div>
+  }
+}
+
+app { root = App; }

--- a/tests/integration/web/scenes/match_arm_reactivity_click.web_test.mjs
+++ b/tests/integration/web/scenes/match_arm_reactivity_click.web_test.mjs
@@ -1,0 +1,28 @@
+// Regression test: state assigned inside a match arm must update the DOM.
+
+export async function run({ page, expect }) {
+  const word = page.locator(".word");
+  const parsed = page.locator(".parsed");
+
+  // Initial state, before any match arm has run.
+  await expect.textContains(word, "start");
+  await expect.textContains(parsed, "none");
+
+  const hit = page.locator(".hit");
+
+  // First click: literal-match arm sets `word`, variant-match arm sets `parsed`.
+  await hit.click();
+  await page.waitForFunction(() => document.querySelector(".word")?.textContent === "one");
+  await expect.textContains(word, "one");
+  await expect.textContains(parsed, "parsed");
+
+  // Second click: a different literal arm fires; the view must track it.
+  await hit.click();
+  await page.waitForFunction(() => document.querySelector(".word")?.textContent === "two");
+  await expect.textContains(word, "two");
+
+  // Third click: the `else` arm fires.
+  await hit.click();
+  await page.waitForFunction(() => document.querySelector(".word")?.textContent === "many");
+  await expect.textContains(word, "many");
+}

--- a/tests/integration/web/scenes_manifest.txt
+++ b/tests/integration/web/scenes_manifest.txt
@@ -4,4 +4,5 @@
 paint_rects|tests/integration/web/scenes/paint_rects.coi|web
 input_zindex_click|tests/integration/web/scenes/input_zindex_click.coi|web
 input_clip_click|tests/integration/web/scenes/input_clip_click.coi|web
+match_arm_reactivity_click|tests/integration/web/scenes/match_arm_reactivity_click.coi|web
 


### PR DESCRIPTION
This pull request fixes a bug where assignments inside match arms did not trigger reactivity (i.e., did not mark fields as dirty for DOM updates). The changes refactor the mutation collection logic so that assignments made inside match arms are properly tracked, ensuring the UI updates as expected. The fix is verified by adding a new regression test and scene.

Key changes include:

### Reactivity and mutation tracking improvements

* Refactored the mutation collection logic by introducing a new helper function `collect_mods_in_expr` to recursively track assignments and mutations in expressions, including those within match arms (`src/ast/statements.cc`). This ensures that any assignment inside a match arm marks the relevant fields as dirty for reactivity. [[1]](diffhunk://#diff-dd0ace0bd3b71588543066f7e2ae4be4ad8c17251e6690d19809cfee93d88459L604-R618) [[2]](diffhunk://#diff-dd0ace0bd3b71588543066f7e2ae4be4ad8c17251e6690d19809cfee93d88459L654-R628) [[3]](diffhunk://#diff-dd0ace0bd3b71588543066f7e2ae4be4ad8c17251e6690d19809cfee93d88459R682-R736)

### Testing and regression coverage

* Added a new integration scene `match_arm_reactivity_click.coi` that assigns state inside match arms and verifies the view is re-rendered accordingly (`tests/integration/web/scenes/match_arm_reactivity_click.coi`).
* Added a corresponding web test `match_arm_reactivity_click.web_test.mjs` to assert that state changes inside match arms are reflected in the DOM (`tests/integration/web/scenes/match_arm_reactivity_click.web_test.mjs`).
* Registered the new test scene in the manifest file to ensure it runs with other integration tests (`tests/integration/web/scenes_manifest.txt`).