### PR TITLE
refactor: collect reactive mods via a generic get_child_nodes() walk

### DIFF
--- a/src/ast/expressions.h
+++ b/src/ast/expressions.h
@@ -260,11 +260,17 @@ struct MatchExpr : Expression {
     std::unique_ptr<Expression> subject;
     std::vector<MatchArm> arms;
     int line = 0;
-    
+
     MatchExpr() = default;
     std::string to_webcc() override;
     void collect_dependencies(std::set<std::string>& deps) override;
     bool is_static() override;
+    std::vector<ASTNode*> get_child_nodes() override {
+        std::vector<ASTNode*> nodes;
+        nodes.push_back(subject.get());
+        for (auto& arm : arms) nodes.push_back(arm.body.get());
+        return nodes;
+    }
 };
 
 // Block expression for match arm bodies that contain statements
@@ -275,4 +281,9 @@ struct BlockExpr : Expression {
     std::string to_webcc() override;
     void collect_dependencies(std::set<std::string>& deps) override;
     bool is_static() override { return false; }
+    std::vector<ASTNode*> get_child_nodes() override {
+        std::vector<ASTNode*> nodes;
+        for (auto& s : statements) nodes.push_back(s.get());
+        return nodes;
+    }
 };

--- a/src/ast/node.h
+++ b/src/ast/node.h
@@ -41,6 +41,12 @@ struct ASTNode {
     virtual std::string to_webcc() { return ""; }
     virtual void collect_dependencies(std::set<std::string>& deps) {}
     virtual void collect_member_dependencies(std::set<MemberDependency>& member_deps) {}
+
+    // Uniform child access for whole-AST traversals that span statements and
+    // expressions (e.g. reactive-mod collection). Override on any node with
+    // children so generic walks never need to enumerate node types by hand.
+    virtual std::vector<ASTNode*> get_child_nodes() { return {}; }
+
     int line = 0;
 };
 
@@ -50,7 +56,16 @@ struct Expression : ASTNode {
     
     // Returns child expressions for traversal. Override in subclasses with children.
     virtual std::vector<Expression*> get_children() { return {}; }
-    
+
+    // Bridge get_children() into the node-level traversal. Nodes with statement
+    // children (BlockExpr, MatchExpr) override get_child_nodes() directly.
+    std::vector<ASTNode*> get_child_nodes() override {
+        std::vector<ASTNode*> nodes;
+        for (auto* child : get_children())
+            if (child) nodes.push_back(child);
+        return nodes;
+    }
+
     // Default implementation: traverse all children
     void collect_dependencies(std::set<std::string>& deps) override {
         for (auto* child : get_children()) {

--- a/src/ast/statements.cc
+++ b/src/ast/statements.cc
@@ -601,21 +601,48 @@ void EmitStatement::collect_dependencies(std::set<std::string> &deps)
     }
 }
 
-// Collect fields mutated by an expression in statement position. Shared by
-// top-level expression statements and match-arm bodies.
-static void collect_mods_in_expr(Expression *expr, std::set<std::string> &mods)
+void collect_mods_recursive(ASTNode *node, std::set<std::string> &mods)
 {
-    if (!expr)
+    if (!node)
         return;
 
-    if (auto postfix = dynamic_cast<PostfixOp *>(expr))
+    // Does this node itself mutate a component field?
+    if (auto assign = dynamic_cast<Assignment *>(node))
+    {
+        mods.insert(assign->name);
+    }
+    else if (auto idxAssign = dynamic_cast<IndexAssignment *>(node))
+    {
+        if (auto id = dynamic_cast<Identifier *>(idxAssign->array.get()))
+        {
+            // Swapping components in a component array needs no DOM sync.
+            if (g_component_array_loops.find(id->name) == g_component_array_loops.end())
+            {
+                mods.insert(id->name);
+            }
+        }
+    }
+    else if (auto memberAssign = dynamic_cast<MemberAssignment *>(node))
+    {
+        // Track the root object being modified (walk out of the member chain).
+        Expression *obj = memberAssign->object.get();
+        while (auto member = dynamic_cast<MemberAccess *>(obj))
+        {
+            obj = member->object.get();
+        }
+        if (auto id = dynamic_cast<Identifier *>(obj))
+        {
+            mods.insert(id->name);
+        }
+    }
+    else if (auto postfix = dynamic_cast<PostfixOp *>(node))
     {
         if (auto id = dynamic_cast<Identifier *>(postfix->operand.get()))
         {
             mods.insert(id->name);
         }
     }
-    else if (auto unary = dynamic_cast<UnaryOp *>(expr))
+    else if (auto unary = dynamic_cast<UnaryOp *>(node))
     {
         if (unary->op == "++" || unary->op == "--")
         {
@@ -625,17 +652,16 @@ static void collect_mods_in_expr(Expression *expr, std::set<std::string> &mods)
             }
         }
     }
-    else if (auto call = dynamic_cast<FunctionCall *>(expr))
+    else if (auto call = dynamic_cast<FunctionCall *>(node))
     {
+        // A void-returning method (string.append, array.push, ...) mutates its
+        // receiver. We lack type info here, so probe every type that has it.
         size_t dot_pos = call->name.rfind('.');
         if (dot_pos != std::string::npos)
         {
             std::string method = call->name.substr(dot_pos + 1);
             std::string obj_expr = call->name.substr(0, dot_pos);
 
-            // Check if this is a mutating method (returns void) on ANY type
-            // This includes: string.append(), array.push(), etc.
-            // We need to check all possible types since we don't have type info here
             bool is_mutating = false;
             std::vector<std::string> types_to_check = {"string", "array", "int", "float", "bool"};
             for (const auto& type : types_to_check)
@@ -650,11 +676,8 @@ static void collect_mods_in_expr(Expression *expr, std::set<std::string> &mods)
 
             if (is_mutating)
             {
-                // For simple identifiers like "label.append()", track "label"
-                // For member access like "rows[i].label.append()", track the root variable
-                // We need to parse obj_expr to find the root identifier
-
-                // Find the root variable name (leftmost identifier before any . or [)
+                // Root variable = leftmost identifier before any '.' or '['
+                // (e.g. "rows[i].label.append()" -> "rows").
                 size_t first_dot = obj_expr.find('.');
                 size_t first_bracket = obj_expr.find('[');
                 size_t split_pos = std::string::npos;
@@ -672,93 +695,22 @@ static void collect_mods_in_expr(Expression *expr, std::set<std::string> &mods)
                     split_pos = first_bracket;
                 }
 
-                std::string root_var = (split_pos != std::string::npos)
-                    ? obj_expr.substr(0, split_pos)
-                    : obj_expr;
-                mods.insert(root_var);
+                mods.insert(split_pos != std::string::npos ? obj_expr.substr(0, split_pos) : obj_expr);
             }
         }
     }
-    else if (auto match = dynamic_cast<MatchExpr *>(expr))
-    {
-        // Descend into arm bodies so assignments inside a match mark fields dirty.
-        for (auto &arm : match->arms)
-        {
-            Expression *body = arm.body.get();
-            if (auto block = dynamic_cast<BlockExpr *>(body))
-            {
-                for (auto &s : block->statements)
-                {
-                    collect_mods_recursive(s.get(), mods);
-                }
-            }
-            else
-            {
-                collect_mods_in_expr(body, mods);
-            }
-        }
-    }
-}
 
-void collect_mods_recursive(Statement *stmt, std::set<std::string> &mods)
-{
-    if (auto assign = dynamic_cast<Assignment *>(stmt))
+    // Descend into every child uniformly. A new node type is covered as soon as
+    // it implements get_child_nodes(); this walk never needs to list them.
+    for (auto *child : node->get_child_nodes())
     {
-        mods.insert(assign->name);
+        collect_mods_recursive(child, mods);
     }
-    else if (auto idxAssign = dynamic_cast<IndexAssignment *>(stmt))
+
+    // After descending: if a foreach's item was mutated (e.g. task.status = ...),
+    // mark the iterable too so parent-level reactive updates run.
+    if (auto forEach = dynamic_cast<ForEachStatement *>(node))
     {
-        if (auto id = dynamic_cast<Identifier *>(idxAssign->array.get()))
-        {
-            // Don't mark component arrays as modified for index assignment
-            // Swapping components doesn't need DOM sync - they're already rendered
-            if (g_component_array_loops.find(id->name) == g_component_array_loops.end())
-            {
-                mods.insert(id->name);
-            }
-        }
-    }
-    else if (auto memberAssign = dynamic_cast<MemberAssignment *>(stmt))
-    {
-        // Track the root object being modified
-        Expression *obj = memberAssign->object.get();
-        while (auto member = dynamic_cast<MemberAccess *>(obj))
-        {
-            obj = member->object.get();
-        }
-        if (auto id = dynamic_cast<Identifier *>(obj))
-        {
-            mods.insert(id->name);
-        }
-    }
-    else if (auto exprStmt = dynamic_cast<ExpressionStatement *>(stmt))
-    {
-        collect_mods_in_expr(exprStmt->expression.get(), mods);
-    }
-    else if (auto block = dynamic_cast<BlockStatement *>(stmt))
-    {
-        for (auto &s : block->statements)
-        {
-            collect_mods_recursive(s.get(), mods);
-        }
-    }
-    else if (auto ifStmt = dynamic_cast<IfStatement *>(stmt))
-    {
-        collect_mods_recursive(ifStmt->then_branch.get(), mods);
-        if (ifStmt->else_branch)
-        {
-            collect_mods_recursive(ifStmt->else_branch.get(), mods);
-        }
-    }
-    else if (auto forRange = dynamic_cast<ForRangeStatement *>(stmt))
-    {
-        collect_mods_recursive(forRange->body.get(), mods);
-    }
-    else if (auto forEach = dynamic_cast<ForEachStatement *>(stmt))
-    {
-        collect_mods_recursive(forEach->body.get(), mods);
-        // If the loop item variable was modified (e.g., task.status = ...),
-        // treat the iterable as modified too so parent-level reactive updates run.
         if (mods.count(forEach->var_name))
         {
             if (auto id = dynamic_cast<Identifier *>(forEach->iterable.get()))

--- a/src/ast/statements.h
+++ b/src/ast/statements.h
@@ -13,6 +13,7 @@ struct VarDeclaration : Statement {
     bool is_move = false;  // true if initialized with &expr (move semantics)
 
     std::string to_webcc() override;
+    std::vector<ASTNode*> get_child_nodes() override { return {initializer.get()}; }
 };
 
 // Component constructor parameter
@@ -27,6 +28,7 @@ struct ComponentParam : Statement {
     bool is_callback = false;
 
     std::string to_webcc() override;
+    std::vector<ASTNode*> get_child_nodes() override { return {default_value.get()}; }
 };
 
 struct Assignment : Statement {
@@ -37,6 +39,7 @@ struct Assignment : Statement {
 
     std::string to_webcc() override;
     void collect_dependencies(std::set<std::string>& deps) override;
+    std::vector<ASTNode*> get_child_nodes() override { return {value.get()}; }
 };
 
 struct IndexAssignment : Statement {
@@ -48,6 +51,7 @@ struct IndexAssignment : Statement {
 
     std::string to_webcc() override;
     void collect_dependencies(std::set<std::string>& deps) override;
+    std::vector<ASTNode*> get_child_nodes() override { return {array.get(), index.get(), value.get()}; }
 };
 
 struct MemberAssignment : Statement {
@@ -59,25 +63,33 @@ struct MemberAssignment : Statement {
 
     std::string to_webcc() override;
     void collect_dependencies(std::set<std::string>& deps) override;
+    std::vector<ASTNode*> get_child_nodes() override { return {object.get(), value.get()}; }
 };
 
 struct ReturnStatement : Statement {
     std::unique_ptr<Expression> value;
-    
+
     std::string to_webcc() override;
     void collect_dependencies(std::set<std::string>& deps) override;
+    std::vector<ASTNode*> get_child_nodes() override { return {value.get()}; }
 };
 
 struct ExpressionStatement : Statement {
     std::unique_ptr<Expression> expression;
     std::string to_webcc() override;
     void collect_dependencies(std::set<std::string>& deps) override;
+    std::vector<ASTNode*> get_child_nodes() override { return {expression.get()}; }
 };
 
 struct BlockStatement : Statement {
     std::vector<std::unique_ptr<Statement>> statements;
     std::string to_webcc() override;
     void collect_dependencies(std::set<std::string>& deps) override;
+    std::vector<ASTNode*> get_child_nodes() override {
+        std::vector<ASTNode*> nodes;
+        for (auto& s : statements) nodes.push_back(s.get());
+        return nodes;
+    }
 };
 
 struct IfStatement : Statement {
@@ -87,6 +99,7 @@ struct IfStatement : Statement {
 
     std::string to_webcc() override;
     void collect_dependencies(std::set<std::string>& deps) override;
+    std::vector<ASTNode*> get_child_nodes() override { return {condition.get(), then_branch.get(), else_branch.get()}; }
 };
 
 struct ForRangeStatement : Statement {
@@ -97,6 +110,7 @@ struct ForRangeStatement : Statement {
 
     std::string to_webcc() override;
     void collect_dependencies(std::set<std::string>& deps) override;
+    std::vector<ASTNode*> get_child_nodes() override { return {start.get(), end.get(), body.get()}; }
 };
 
 struct ForEachStatement : Statement {
@@ -106,6 +120,7 @@ struct ForEachStatement : Statement {
 
     std::string to_webcc() override;
     void collect_dependencies(std::set<std::string>& deps) override;
+    std::vector<ASTNode*> get_child_nodes() override { return {iterable.get(), body.get()}; }
 };
 
 struct EmitStatement : Statement {
@@ -114,7 +129,13 @@ struct EmitStatement : Statement {
 
     std::string to_webcc() override;
     void collect_dependencies(std::set<std::string>& deps) override;
+    std::vector<ASTNode*> get_child_nodes() override {
+        std::vector<ASTNode*> nodes;
+        for (auto& a : args) nodes.push_back(a.get());
+        return nodes;
+    }
 };
 
-// Recursively collect modified variables in statements
-void collect_mods_recursive(Statement* stmt, std::set<std::string>& mods);
+// Recursively collect the component fields a subtree mutates. Walks any node via
+// get_child_nodes(), so new node types are covered without editing this walk.
+void collect_mods_recursive(ASTNode* node, std::set<std::string>& mods);


### PR DESCRIPTION
This pull request refactors AST traversal to enable more generic and uniform analysis across statements and expressions, particularly for mutation tracking. The key improvement is the introduction and widespread implementation of a `get_child_nodes()` method on AST node types, which allows recursive algorithms to traverse the entire AST without manual type dispatch. This greatly simplifies and generalizes how code can analyze or transform the AST.

The most important changes are:

**AST Traversal Infrastructure:**

* Added a virtual `get_child_nodes()` method to the base `ASTNode` class, and implemented it for all relevant statement and expression node types, enabling uniform traversal of the AST for analyses that span both statements and expressions. [[1]](diffhunk://#diff-951c23673ca5730e91218bdebe31acf273bf13903c47c2911d6e9b44ea8ac412R44-R49) [[2]](diffhunk://#diff-951c23673ca5730e91218bdebe31acf273bf13903c47c2911d6e9b44ea8ac412R60-R68) [[3]](diffhunk://#diff-0c66d940ea30b305ac2475306a5b1278093f03710b791c0c9d37cfc2c4fda058R268-R273) [[4]](diffhunk://#diff-0c66d940ea30b305ac2475306a5b1278093f03710b791c0c9d37cfc2c4fda058R284-R288) [[5]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R16) [[6]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R31) [[7]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R42) [[8]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R54) [[9]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R66-R92) [[10]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R102) [[11]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R113) [[12]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R123) [[13]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R132-R141)

**Mutation Analysis Refactor:**

* Refactored the mutation collection logic (`collect_mods_recursive`) to operate on `ASTNode*` and leverage `get_child_nodes()` for traversal, eliminating the need for manual type checks and making the analysis automatically support new node types. [[1]](diffhunk://#diff-dd0ace0bd3b71588543066f7e2ae4be4ad8c17251e6690d19809cfee93d88459L604-R645) [[2]](diffhunk://#diff-dd0ace0bd3b71588543066f7e2ae4be4ad8c17251e6690d19809cfee93d88459L628-L638) [[3]](diffhunk://#diff-dd0ace0bd3b71588543066f7e2ae4be4ad8c17251e6690d19809cfee93d88459L653-R680) [[4]](diffhunk://#diff-dd0ace0bd3b71588543066f7e2ae4be4ad8c17251e6690d19809cfee93d88459L675-L761) [[5]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R132-R141)

**Code Simplification and Maintainability:**

* Removed the old, type-specific traversal logic for mutation collection, replacing it with a single, generic walk that requires no updates when new node types are added, thus reducing boilerplate and future maintenance.

**Documentation and Comments:**

* Added explanatory comments throughout the code to clarify the purpose and usage of `get_child_nodes()` and the new traversal strategy, aiding future contributors in understanding the design. [[1]](diffhunk://#diff-951c23673ca5730e91218bdebe31acf273bf13903c47c2911d6e9b44ea8ac412R44-R49) [[2]](diffhunk://#diff-951c23673ca5730e91218bdebe31acf273bf13903c47c2911d6e9b44ea8ac412R60-R68) [[3]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R132-R141)

**Consistency Improvements:**

* Ensured all relevant statement and expression nodes (e.g., `BlockStatement`, `IfStatement`, `ForEachStatement`, etc.) now consistently expose their children via `get_child_nodes()`, guaranteeing that generic traversals see the entire subtree. [[1]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R16) [[2]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R31) [[3]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R42) [[4]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R54) [[5]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R66-R92) [[6]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R102) [[7]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R113) [[8]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R123) [[9]](diffhunk://#diff-fdb7ad5ab0d09005dc59bce4a985f7bfca49b5b968dd2dae5556f84e9ecd0d52R132-R141) [[10]](diffhunk://#diff-0c66d940ea30b305ac2475306a5b1278093f03710b791c0c9d37cfc2c4fda058R268-R273) [[11]](diffhunk://#diff-0c66d940ea30b305ac2475306a5b1278093f03710b791c0c9d37cfc2c4fda058R284-R288)