### PR TITLE
Fix text node binding by creating DOM Text nodes with value setting

### DIFF
--- a/src/ast/component/to_webcc.cc
+++ b/src/ast/component/to_webcc.cc
@@ -769,6 +769,12 @@ std::string Component::to_webcc(CompilerSession &session)
         } else if (binding.type == "html") {
             // Raw HTML injection via <raw> element
             dom_call = "webcc::dom::set_inner_html(" + el_var + ", ";
+        } else if (binding.type == "textnode") {
+            // A bare interpolation that sits next to sibling elements is created as
+            // a real DOM Text node (create_text_node), not an element. Text nodes
+            // have no settable innerText, so set_inner_text is a silent no-op and
+            // the value freezes at its initial render. Update via nodeValue.
+            dom_call = "webcc::dom::set_node_value(" + el_var + ", ";
         } else {
             dom_call = "webcc::dom::set_inner_text(" + el_var + ", ";
         }


### PR DESCRIPTION
This pull request updates the handling of text node bindings in the `Component::to_webcc` method to ensure that updates to text nodes are properly reflected in the DOM. The most important change is:

DOM text node binding improvements:

* [`src/ast/component/to_webcc.cc`](diffhunk://#diff-56a96d5754695969d4a991358d6eb590f689db46e16ddde1e81aa62bdcfad606R772-R777): Added a special case for `textnode` bindings to use `webcc::dom::set_node_value` instead of `set_inner_text`, ensuring that updates to text nodes are correctly applied at runtime.…_value