### PR TITLE
Implement tick forwarding for logic-only state members and add tests

### DIFF
--- a/src/ast/component/emit_lifecycle.cc
+++ b/src/ast/component/emit_lifecycle.cc
@@ -1,5 +1,25 @@
 #include "component.h"
 
+// Resolve a component reference as it appears at a use site (a view child key
+// like "Button" or "TurboUI_Button", a state type like "Store" or
+// "Turbo::Store", a route target) to the canonical qualified component name
+// used as the key of session.component_info and session.components_with_tick.
+// Returns "" if the name does not refer to a component (e.g. a pod type).
+static std::string resolve_component_qname(const CompilerSession &session,
+                                           const std::string &module_name,
+                                           std::string name)
+{
+    size_t dcolon = name.find("::");
+    if (dcolon != std::string::npos)
+        name = name.substr(0, dcolon) + "_" + name.substr(dcolon + 2);
+    if (session.component_info.count(name))
+        return name;
+    std::string same_module = qualified_name(module_name, name);
+    if (session.component_info.count(same_module))
+        return same_module;
+    return "";
+}
+
 void emit_component_lifecycle_methods(std::stringstream &ss,
                                       CompilerSession &session,
                                       const Component &component,
@@ -372,14 +392,40 @@ void emit_component_lifecycle_methods(std::stringstream &ss,
                 user_tick_has_args = true;
         }
 
+    // Whether a component reference at a use site resolves to a component that
+    // emitted a tick method. Topological sort guarantees children (view,
+    // state-member, and route dependencies alike) are emitted before their
+    // parents, so components_with_tick is complete for every name checked here.
+    auto ticks = [&](const std::string &name) {
+        std::string qname = resolve_component_qname(session, component.module_name, name);
+        return !qname.empty() && session.components_with_tick.count(qname) > 0;
+    };
+
     bool has_child_with_tick = false;
     for (auto const &[comp_name, count] : component_members)
     {
-        if (session.components_with_tick.count(comp_name))
+        if (ticks(comp_name))
         {
             has_child_with_tick = true;
             break;
         }
+    }
+
+    // Component-typed state members (e.g. a logic-only Store, or a member
+    // mounted via <{name}/>) never appear in component_members, which only
+    // covers components instantiated directly in the view, so collect them
+    // here or they would never receive tick. Reference members are skipped:
+    // the component that owns them forwards tick to them.
+    std::vector<const VarDeclaration *> tickable_state_members;
+    for (const auto &var : component.state)
+    {
+        if (var->is_reference)
+            continue;
+        std::string base_type = var->type;
+        if (base_type.ends_with("[]"))
+            base_type = base_type.substr(0, base_type.size() - 2);
+        if (ticks(base_type))
+            tickable_state_members.push_back(var.get());
     }
 
     // Router-mounted pages are dynamic children too: if any route target has a
@@ -391,7 +437,7 @@ void emit_component_lifecycle_methods(std::stringstream &ss,
     {
         for (auto const &route : component.router->routes)
         {
-            if (session.components_with_tick.count(route.component_name))
+            if (ticks(qualified_name(route.module_name, route.component_name)))
             {
                 has_route_with_tick = true;
                 break;
@@ -399,10 +445,11 @@ void emit_component_lifecycle_methods(std::stringstream &ss,
         }
     }
 
-    bool needs_tick = has_user_tick || has_child_with_tick || has_route_with_tick;
+    bool needs_tick = has_user_tick || has_child_with_tick || has_route_with_tick ||
+                      !tickable_state_members.empty();
     if (needs_tick)
     {
-        session.components_with_tick.insert(component.name);
+        session.components_with_tick.insert(qualified_name(component.module_name, component.name));
         ss << "    void tick(double dt) {\n";
 
         if (has_user_tick)
@@ -415,7 +462,7 @@ void emit_component_lifecycle_methods(std::stringstream &ss,
 
         for (auto const &[comp_name, count] : component_members)
         {
-            if (session.components_with_tick.count(comp_name))
+            if (ticks(comp_name))
             {
                 for (int i = 0; i < count; ++i)
                 {
@@ -424,13 +471,22 @@ void emit_component_lifecycle_methods(std::stringstream &ss,
             }
         }
 
+        for (const auto *var : tickable_state_members)
+        {
+            if (var->type.ends_with("[]"))
+                ss << "        for (auto &_c : " << var->name << ") _c.tick(dt);\n";
+            else
+                ss << "        " << var->name << ".tick(dt);\n";
+        }
+
         // Forward tick to the currently-mounted route page. Route pages are heap
         // pointers, so guard on non-null (inactive routes are nullptr).
         if (component.router)
         {
             for (size_t i = 0; i < component.router->routes.size(); ++i)
             {
-                if (session.components_with_tick.count(component.router->routes[i].component_name))
+                const auto &route = component.router->routes[i];
+                if (ticks(qualified_name(route.module_name, route.component_name)))
                 {
                     ss << "        if (_route_" << i << ") _route_" << i << "->tick(dt);\n";
                 }

--- a/src/ast/node.h
+++ b/src/ast/node.h
@@ -19,7 +19,7 @@ struct ComponentMemberInfo {
 
 // Cross-component state that persists across all components in one compilation
 struct CompilerSession {
-    std::set<std::string> components_with_tick;  // Components that have tick methods
+    std::set<std::string> components_with_tick;  // Qualified names of components whose emitted struct has a tick method
     std::map<std::string, ComponentMemberInfo> component_info;  // Component name -> member info
     std::set<std::string> data_type_names;  // Fully-qualified data type names (e.g., "Supabase_Credentials")
 };

--- a/tests/integration/web/scenes/member_tick_click.coi
+++ b/tests/integration/web/scenes/member_tick_click.coi
@@ -1,0 +1,36 @@
+// Regression scene: a logic-only component held as a state member must
+// receive tick even though it never appears in the view. App itself has no
+// tick, so the generated App.tick exists purely to forward to the member.
+
+component FrameStore {
+    pub mut int frames = 0;
+
+    tick(float dt) {
+        frames++;
+    }
+}
+
+component App {
+    mut FrameStore store;
+    mut int sampled = -1;
+
+    def sample() : void {
+        sampled = store.frames;
+    }
+
+    style {
+        html, body { margin: 0; padding: 0; background: #0f1117; color: #e8e8e8;
+            font-family: system-ui, sans-serif; }
+        .hit { width: 100vw; height: 100vh; display: flex; align-items: center;
+            justify-content: center; user-select: none; cursor: pointer; }
+        .sampled { font-size: 40px; }
+    }
+
+    view {
+        <div class="hit hit" onclick={sample}>
+            <div class="sampled sampled">{sampled}</div>
+        </div>
+    }
+}
+
+app { root = App; }

--- a/tests/integration/web/scenes/member_tick_click.web_test.mjs
+++ b/tests/integration/web/scenes/member_tick_click.web_test.mjs
@@ -1,0 +1,20 @@
+// Regression test: a logic-only state member component must be ticked every
+// frame. Clicking samples the member's frame counter into the view; if tick
+// was never forwarded to the member, the counter stays at 0.
+
+export async function run({ page, expect }) {
+  const sampled = page.locator(".sampled");
+
+  // Nothing sampled yet.
+  await expect.textContains(sampled, "-1");
+
+  // Let a few frames run so the member's tick can accumulate.
+  await page.waitForTimeout(300);
+
+  const hit = page.locator(".hit");
+  await hit.click();
+  await page.waitForFunction(() => {
+    const text = document.querySelector(".sampled")?.textContent ?? "";
+    return parseInt(text, 10) > 0;
+  });
+}

--- a/tests/integration/web/scenes_manifest.txt
+++ b/tests/integration/web/scenes_manifest.txt
@@ -6,4 +6,5 @@ input_zindex_click|tests/integration/web/scenes/input_zindex_click.coi|web
 input_clip_click|tests/integration/web/scenes/input_clip_click.coi|web
 match_arm_reactivity_click|tests/integration/web/scenes/match_arm_reactivity_click.coi|web
 router_params_click|tests/integration/web/scenes/router_params_click.coi|web
+member_tick_click|tests/integration/web/scenes/member_tick_click.coi|web
 

--- a/tests/unit/component/member_tick_pass.coi
+++ b/tests/unit/component/member_tick_pass.coi
@@ -1,0 +1,26 @@
+// Test: a logic-only component held as a state member gets tick forwarded
+// even though it never appears in the view
+component FrameStore {
+    pub mut int frames = 0;
+
+    tick(float dt) {
+        frames++;
+    }
+}
+
+component MemberTickPass {
+    mut FrameStore store;
+    mut int sampled = 0;
+
+    def sample() : void {
+        sampled = store.frames;
+    }
+
+    view {
+        <button onclick={sample}>{sampled}</button>
+    }
+}
+
+app {
+    root = MemberTickPass;
+}


### PR DESCRIPTION
This pull request improves the component lifecycle handling to ensure that logic-only components held as state members receive `tick` events, even if they are not directly instantiated in the view. Previously, only components present in the view or as route targets would have their `tick` methods called. The changes introduce logic to detect and forward `tick` to all relevant state members and add regression tests to prevent future issues.

**Component lifecycle and tick propagation:**

* Added the `resolve_component_qname` helper to consistently resolve component references to their fully qualified names, ensuring accurate lookups in `components_with_tick`.
* Updated the tick propagation logic in `emit_component_lifecycle_methods` to:
  - Identify and collect component-typed state members that require ticking, even if they are not present in the view.
  - Forward `tick` calls to these state members in the generated code.
  - Use fully qualified names throughout tick detection and registration for consistency. [[1]](diffhunk://#diff-4ca7d2755a1a20c1733e3acb4d62a673e0494d08c8f3d6fc31ad181f49a7aa01L394-R452) [[2]](diffhunk://#diff-4ca7d2755a1a20c1733e3acb4d62a673e0494d08c8f3d6fc31ad181f49a7aa01L418-R465)
* Improved documentation in `CompilerSession` to clarify that `components_with_tick` stores qualified component names.

**Testing and regression coverage:**

* Added an integration test and scene (`member_tick_click`) to verify that state member components with tick methods are properly updated, even when not present in the view. [[1]](diffhunk://#diff-678e26b3850db23c90da980a9602c79b9bf5c649f6b8284704d8cb6c16631354R1-R36) [[2]](diffhunk://#diff-0ecb2c0a49973cb7c2746b313fe8e2eef36ceb625aaa3399700120ee4d18f3eaR1-R20) [[3]](diffhunk://#diff-32b1a68cc566b66cdbacb5779d75acdee1cf436a453781e53e200823a2af7dbdR9)
* Added a unit test (`member_tick_pass.coi`) to ensure that logic-only state members receive tick events.…egression tests