### PR TITLE
Transform append_child to insert_before for anchor regions and update rendering

### DIFF
--- a/src/ast/component/to_webcc.cc
+++ b/src/ast/component/to_webcc.cc
@@ -20,6 +20,8 @@ static std::string make_callback_name(const std::string &var_name)
 // Transform append_child calls to insert_before for anchor-based regions
 // Transforms: webcc::dom::append_child(parent_var, el[N]);
 // To:         webcc::dom::insert_before(parent_var, el[N], anchor_var);
+// Also rewrites child component renders (which append their roots internally)
+// to the anchor-aware form: X.view(parent_var); -> X.view(parent_var, anchor_var);
 static std::string transform_to_insert_before(const std::string &code, const std::string &parent_var, const std::string &anchor_var)
 {
     std::string result;
@@ -46,6 +48,18 @@ static std::string transform_to_insert_before(const std::string &code, const std
     }
 
     result += code.substr(last_pos);
+
+    // Child components attach their own roots inside view(); pass the anchor
+    // through so they keep their position too (an invalid anchor appends).
+    std::string view_pattern = ".view(" + parent_var + ");";
+    std::string view_replacement = ".view(" + parent_var + ", " + anchor_var + ");";
+    size_t vpos = 0;
+    while ((vpos = result.find(view_pattern, vpos)) != std::string::npos)
+    {
+        result.replace(vpos, view_pattern.length(), view_replacement);
+        vpos += view_replacement.length();
+    }
+
     return result;
 }
 
@@ -1610,8 +1624,11 @@ std::string Component::to_webcc(CompilerSession &session)
         ss << "    }\n";
     }
 
-    // View method
-    ss << "    void view(webcc::handle parent = webcc::dom::get_body()) {\n";
+    // View method. _before is an optional anchor: when valid, the component's
+    // roots are inserted before it instead of appended, so components created
+    // inside anchor-based regions (<if>/<for> re-syncs) keep their position.
+    // An invalid handle appends (see dom INSERT_BEFORE: insertBefore(el, ref || null)).
+    ss << "    void view(webcc::handle parent = webcc::dom::get_body(), webcc::handle _before = webcc::handle()) {\n";
     ss << "        g_view_depth++;\n";
 
     bool has_init = false;
@@ -1627,7 +1644,10 @@ std::string Component::to_webcc(CompilerSession &session)
         ss << "        _user_init();\n";
     if (!render_roots.empty())
     {
-        ss << ss_render.str();
+        // Attach roots (and root-level child components) relative to _before.
+        // Only top-level attaches use the literal "parent" var, so nested
+        // append_child(el[N], ...) calls are untouched.
+        ss << transform_to_insert_before(ss_render.str(), "parent", "_before");
     }
     // End view - flushes only at outermost level, then register event handlers
     ss << "        if (--g_view_depth == 0) webcc::flush();\n";

--- a/src/ast/view.cc
+++ b/src/ast/view.cc
@@ -44,6 +44,8 @@ static std::string build_forward_args(size_t count)
 // Helper to transform append_child calls to insert_before for anchor-based if regions
 // Transforms: webcc::dom::append_child(_if_X_parent, el[N]);
 // To:         webcc::dom::insert_before(_if_X_parent, el[N], _if_X_anchor);
+// Also rewrites child component renders (which append their roots internally)
+// to the anchor-aware form: X.view(_if_X_parent); -> X.view(_if_X_parent, _if_X_anchor);
 static std::string transform_to_insert_before(const std::string& code, const std::string& if_parent, const std::string& if_anchor) {
     std::string result;
     std::string search_pattern = "webcc::dom::append_child(" + if_parent + ", ";
@@ -71,9 +73,20 @@ static std::string transform_to_insert_before(const std::string& code, const std
         
         last_pos = end_pos + 2; // Skip past ");"
     }
-    
+
     // Copy remaining content
     result += code.substr(last_pos);
+
+    // Child components attach their own roots inside view(); pass the anchor
+    // through so they keep their position too (an invalid anchor appends).
+    std::string view_pattern = ".view(" + if_parent + ");";
+    std::string view_replacement = ".view(" + if_parent + ", " + if_anchor + ");";
+    size_t vpos = 0;
+    while ((vpos = result.find(view_pattern, vpos)) != std::string::npos) {
+        result.replace(vpos, view_pattern.length(), view_replacement);
+        vpos += view_replacement.length();
+    }
+
     return result;
 }
 


### PR DESCRIPTION
This pull request enhances anchor-based rendering in the code generation logic for components and view regions. The main improvement is ensuring that child components and their roots are consistently inserted before a specified anchor (rather than always appended), which helps preserve their position in dynamic regions such as those managed by `<if>` or `<for>` constructs. This is achieved by updating both the generated `view` methods and the transformation logic for code generation.

**Component anchor-aware rendering:**

* The generated `view` method in `Component` now accepts an optional `_before` (anchor) argument, so roots and child components can be inserted before a specific DOM node, not just appended.
* When rendering roots and root-level child components, the code now uses `transform_to_insert_before` to rewrite `append_child` and `view` calls to use the anchor, ensuring correct placement.

**Transformation logic updates:**

* The `transform_to_insert_before` function in both `src/ast/component/to_webcc.cc` and `src/ast/view.cc` now also rewrites child component `view` calls to include the anchor argument, not just `append_child` calls. [[1]](diffhunk://#diff-56a96d5754695969d4a991358d6eb590f689db46e16ddde1e81aa62bdcfad606R23-R24) [[2]](diffhunk://#diff-359e6eb55861055c44c3d4ff610da948715d1ad5d6fdb49026d34c20c3242b94R47-R48)
* The anchor-aware transformation is applied by searching for `.view(parent_var);` and replacing it with `.view(parent_var, anchor_var);` in the generated code. [[1]](diffhunk://#diff-56a96d5754695969d4a991358d6eb590f689db46e16ddde1e81aa62bdcfad606R51-R62) [[2]](diffhunk://#diff-359e6eb55861055c44c3d4ff610da948715d1ad5d6fdb49026d34c20c3242b94R79-R89)

These changes ensure that components rendered inside anchor-based regions maintain their intended position, even when the DOM is updated dynamically.…egions and update child component rendering