### PR TITLE
Add guards for unrendered components in lifecycle methods

### DIFF
--- a/src/ast/component/emit_lifecycle.cc
+++ b/src/ast/component/emit_lifecycle.cc
@@ -239,6 +239,14 @@ void emit_component_lifecycle_methods(std::stringstream &ss,
     // skip_dom_removal: if true, only unregisters handlers (caller will bulk-clear DOM)
     ss << "    void _remove_view(bool skip_dom_removal = false) {\n";
 
+    // Never rendered (e.g. a member component inside a region whose condition
+    // was never true): nothing to remove, no handlers to unregister, and the
+    // el/anchor handles are still invalid, so removing would warn JS-side.
+    if (root_if_id >= 0 && !if_regions.empty())
+        ss << "        if (!_if_" << root_if_id << "_anchor.is_valid()) return;\n";
+    else if (element_count > 0)
+        ss << "        if (!el[0].is_valid()) return;\n";
+
     // If we have if/else at root level, handle both branches
     if (root_if_id >= 0 && !if_regions.empty())
     {

--- a/src/ast/component/to_webcc.cc
+++ b/src/ast/component/to_webcc.cc
@@ -1233,6 +1233,10 @@ std::string Component::to_webcc(CompilerSession &session)
     for (const auto &region : if_regions)
     {
         ss << "    void _sync_if_" << region.if_id << "() {\n";
+        // Not rendered yet (e.g. state mutated through a pub method before the
+        // first view()): nothing to sync; view() renders the live condition
+        // inline. Mirrors the _loop_N_parent guard in loop syncs.
+        ss << "        if (!_if_" << region.if_id << "_parent.is_valid()) return;\n";
         ss << "        bool new_state = " << region.condition_code << ";\n";
         ss << "        if (new_state == _if_" << region.if_id << "_state) return;\n";
         ss << "        _if_" << region.if_id << "_state = new_state;\n";


### PR DESCRIPTION
This pull request introduces additional guard checks to prevent unnecessary or invalid DOM operations in component lifecycle methods and conditional region syncing. These changes ensure that component removal and synchronization logic only execute when the relevant DOM elements or regions have actually been rendered, avoiding potential errors or warnings.

**Lifecycle and conditional region guard improvements:**

* [`src/ast/component/emit_lifecycle.cc`](diffhunk://#diff-4ca7d2755a1a20c1733e3acb4d62a673e0494d08c8f3d6fc31ad181f49a7aa01R242-R249): Added checks in `_remove_view` to return early if the root conditional region or main element has not been rendered, preventing attempts to remove or unregister handlers for non-existent DOM elements.
* [`src/ast/component/to_webcc.cc`](diffhunk://#diff-56a96d5754695969d4a991358d6eb590f689db46e16ddde1e81aa62bdcfad606R1236-R1239): Added a guard in `_sync_if_N` methods to return early if the parent anchor for the conditional region is not valid, ensuring that synchronization only happens for rendered regions.