### PR TITLE
Implement routing state management and apply route method

### DIFF
--- a/src/ast/component/emit_router.cc
+++ b/src/ast/component/emit_router.cc
@@ -7,13 +7,20 @@ void emit_component_router_methods(std::stringstream &ss, const Component &compo
         return;
     }
 
-    // navigate() method - changes route and updates browser URL
+    // navigate() method - changes route and updates browser URL.
+    // The actual route swap is DEFERRED to _apply_route() (called from
+    // update_wrapper at a safe point): navigate() is typically invoked from a
+    // method of the route component that is about to be destroyed, and a
+    // synchronous _sync_route() would delete that component while its method
+    // is still on the stack. The generated epilogue (_update_*/_sync_if_*)
+    // would then run on freed memory — use-after-free, DOM handle garbage,
+    // and eventually OOB crashes (timing/data dependent).
     ss << "    void navigate(const coi::string& route) {\n";
     ss << "        if (_current_route == route) return;\n";
     ss << "        _current_route = route;\n";
     ss << "        webcc::system::push_state(route);\n";
     ss << "        webcc::dom::scroll_to_top();\n";
-    ss << "        _sync_route();\n";
+    ss << "        _route_dirty = true;\n";
     ss << "    }\n";
 
     // _handle_popstate() method - called when browser back/forward buttons are clicked
@@ -21,6 +28,15 @@ void emit_component_router_methods(std::stringstream &ss, const Component &compo
     ss << "        if (_current_route == path) return;\n";
     ss << "        _current_route = path;\n";
     // For popstate, we don't need to validate - _sync_route will handle fallback via else
+    ss << "        _route_dirty = true;\n";
+    ss << "    }\n";
+
+    // _apply_route() - performs a pending route swap. Called from
+    // update_wrapper after all events/ticks have been dispatched, so no
+    // route component method is on the stack when components are destroyed.
+    ss << "    void _apply_route() {\n";
+    ss << "        if (!_route_dirty) return;\n";
+    ss << "        _route_dirty = false;\n";
     ss << "        _sync_route();\n";
     ss << "    }\n";
 

--- a/src/ast/component/to_webcc.cc
+++ b/src/ast/component/to_webcc.cc
@@ -703,6 +703,7 @@ std::string Component::to_webcc(CompilerSession &session)
     if (router)
     {
         ss << "    coi::string _current_route;\n";
+        ss << "    bool _route_dirty = false;\n";
         ss << "    webcc::handle _route_parent;\n";
         ss << "    webcc::handle _route_anchor;\n";
         // Generate component pointers for each route

--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -414,6 +414,13 @@ void generate_cpp_code(
     {
         out << "    if (app) app->tick(dt);\n";
     }
+    if (features.router)
+    {
+        // Apply any route change requested during event dispatch or tick.
+        // Deferring the swap here guarantees no route component method is on
+        // the stack when its component gets destroyed (see emit_router.cc).
+        out << "    if (app) app->_apply_route();\n";
+    }
     out << "    webcc::flush();\n";
     out << "}\n\n";
 


### PR DESCRIPTION
This pull request refactors how route changes are handled in the router component to prevent use-after-free bugs and potential crashes. Instead of applying route changes immediately (which could destroy components while their methods are still on the call stack), the route swap is now deferred and applied safely after all events and ticks are processed.

**Router lifecycle and safety improvements:**

* The `navigate()` and `_handle_popstate()` methods now mark the route as dirty (`_route_dirty = true`) instead of synchronously applying the route change. The actual route swap is performed later by the new `_apply_route()` method, which is called at a safe point after all events and ticks have been dispatched. This prevents use-after-free errors and timing-dependent crashes.
* Added a new `_route_dirty` boolean member to the router component to track pending route changes.
* The main event loop now calls `_apply_route()` after processing events/ticks if routing is enabled, ensuring that route swaps only happen when it is safe.